### PR TITLE
users_add_delivery

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   
   protected
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :family_name, :family_name_kana, :first_name, :first_name_kana, :birth_year, :birth_month, :birth_day])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :family_name, :family_name_kana, :first_name, :first_name_kana, :birth_year, :birth_month, :birth_day, :delivery_first_name, :delivery_family_name, :delivery_first_name_kana, :delivery_family_name_kana, :prefectures, :municipality, :address, :postal_code])
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,5 +8,5 @@ class User < ApplicationRecord
   has_one  :deliver_adresses, dependent: :destroy
   has_many :cards
 
-  validates :nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day, :password, :email, presence: true
+  validates :nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day, :password, :email, :delivery_first_name, :delivery_family_name, :delivery_first_name_kana, :delivery_family_name_kana, :prefectures, :municipality, :address, :postal_code, presence: true
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -24,7 +24,7 @@
         .field
       .user-main__field
         = f.label :パスワード再確認, class:'user-form-group'
-        %br/
+        %br/ 
         = f.password_field :password_confirmation, class:'user-field', autocomplete: "new-password"
         %br/
         %h3 ※ 英字と数字の両方を含めて設定してください
@@ -50,6 +50,40 @@
         = f.text_field :family_name_kana, class:'user-field2', placeholder: "例） ハヤシ"
         = f.text_field :first_name_kana, class:'user-field2', placeholder: "例） タク"
         %br/
+        .user-main__field
+        = f.label :送付先氏名（全角）
+        %span ※必須
+        %br/
+        = f.text_field :delivery_family_name, class:'user-field2', placeholder: "名字"
+        = f.text_field :delivery_first_name, class:'user-field2', placeholder: "名前"
+        %br/
+      .user-main__field
+        = f.label :送付先氏名カナ（全角）
+        %span ※必須
+        %br/
+        = f.text_field :delivery_family_name_kana, class:'user-field2', placeholder: "カナ"
+        = f.text_field :delivery_first_name_kana, class:'user-field2', placeholder: "カナ"
+        %br/
+      .user-main__field
+        = f.label :郵便番号
+        %span ※必須
+        = f.text_field :postal_code, class:'user-field', placeholder: "ハイフン不要"
+        %br/
+      .user-main__field
+        = f.label :都道府県
+        %span ※必須
+        = f.text_field :prefectures, class:'user-field'
+        %br/
+      .user-main__field
+        = f.label :市区町村
+        %span ※必須
+        = f.text_field :municipality, class:'user-field'
+        %br/
+      .user-main__field
+        = f.label :◯◯番地
+        %span ※必須
+        = f.text_field :address, class:'user-field'
+        %br/ 
       .user-main__field
         = f.label :生年月日
         %span ※必須

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -28,6 +28,10 @@
             %span 支払い方法
             %span >
         %li
+          = link_to "#" do
+            %span 発送元・お届け先住所
+            %span >
+        %li
           = link_to "/users/logout" do
             %span ログアウト
             %span >

--- a/db/migrate/20200226064012_add_delivery_first_name_to_users.rb
+++ b/db/migrate/20200226064012_add_delivery_first_name_to_users.rb
@@ -1,0 +1,12 @@
+class AddDeliveryFirstNameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :delivery_first_name, :string, null:false
+    add_column :users, :delivery_family_name, :string, null:false
+    add_column :users, :delivery_first_name_kana, :string, null:false
+    add_column :users, :delivery_family_name_kana, :string, null:false
+    add_column :users, :postal_code, :string, null:false
+    add_column :users, :prefectures, :string, null:false
+    add_column :users, :municipality, :string, null:false
+    add_column :users, :address, :string, null:false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_074934) do
+ActiveRecord::Schema.define(version: 2020_02_26_064012) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "category_id", null: false
@@ -122,6 +122,14 @@ ActiveRecord::Schema.define(version: 2020_02_24_074934) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "image"
+    t.string "delivery_first_name", null: false
+    t.string "delivery_family_name", null: false
+    t.string "delivery_first_name_kana", null: false
+    t.string "delivery_family_name_kana", null: false
+    t.string "postal_code", null: false
+    t.string "prefectures", null: false
+    t.string "municipality", null: false
+    t.string "address", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# what
既存のusersテーブル配送などのカラムの追加
validation,application_controllerのsign_upのkeyに追記

# why
新規登録時に配送先の名前と住所を追加する為